### PR TITLE
Feat#5: ERD 2차 버전으로 코드 수정

### DIFF
--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -1,0 +1,36 @@
+package server.poptato.category.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private Long userId;
+    @NotNull
+    private Long emoji_id;
+    @NotNull
+    private int category_order;
+    @NotNull
+    private String name;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/server/poptato/emoji/domain/entity/Emoji.java
+++ b/src/main/java/server/poptato/emoji/domain/entity/Emoji.java
@@ -1,0 +1,35 @@
+package server.poptato.emoji.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.lang.Nullable;
+import server.poptato.emoji.domain.value.GroupName;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Emoji {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private String imageUrl;
+    @Nullable
+    @Enumerated(EnumType.STRING)
+    private GroupName groupName;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}
+

--- a/src/main/java/server/poptato/emoji/domain/value/GroupName.java
+++ b/src/main/java/server/poptato/emoji/domain/value/GroupName.java
@@ -1,0 +1,5 @@
+package server.poptato.emoji.domain.value;
+
+public enum GroupName {
+    생산성
+}

--- a/src/main/java/server/poptato/todo/api/TodoController.java
+++ b/src/main/java/server/poptato/todo/api/TodoController.java
@@ -12,6 +12,8 @@ import server.poptato.todo.application.TodoService;
 import server.poptato.todo.application.response.TodoDetailResponseDto;
 import server.poptato.user.resolver.UserId;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequiredArgsConstructor
 public class TodoController {
@@ -68,9 +70,9 @@ public class TodoController {
     }
 
     @PatchMapping("/todo/{todoId}/achieve")
-    public BaseResponse updateIsCompleted(@UserId Long userId,
+    public BaseResponse updateIsCompleted(//@UserId Long userId,
                                           @PathVariable Long todoId) {
-        todoService.updateIsCompleted(userId, todoId);
+        todoService.updateIsCompleted(1L, todoId, LocalDateTime.now());
         return new BaseResponse<>();
     }
 }

--- a/src/main/java/server/poptato/todo/application/TodoBacklogService.java
+++ b/src/main/java/server/poptato/todo/application/TodoBacklogService.java
@@ -49,9 +49,8 @@ public class TodoBacklogService {
     }
 
     private Page<Todo> getHistoriesPage(Long userId, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "completedDateTime"));
-        LocalDate today = LocalDate.now();
-        Page<Todo> historiesPage = todoRepository.findHistories(userId, today, pageable);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Todo> historiesPage = todoRepository.findHistories(userId, pageable);
         return historiesPage;
     }
 

--- a/src/main/java/server/poptato/todo/application/TodoTodayService.java
+++ b/src/main/java/server/poptato/todo/application/TodoTodayService.java
@@ -48,7 +48,7 @@ public class TodoTodayService {
         List<Todo> todays = new ArrayList<>();
 
         List<Todo> incompleteTodos = todoRepository.findIncompleteTodays(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE);
-        List<Todo> completedTodos = todoRepository.findCompletedTodays(userId, Type.TODAY, todayDate, TodayStatus.COMPLETED);
+        List<Todo> completedTodos = todoRepository.findCompletedTodays(userId, todayDate);
 
         todays.addAll(incompleteTodos);
         todays.addAll(completedTodos);

--- a/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/HistoryResponseDto.java
@@ -4,5 +4,5 @@ import lombok.Builder;
 import java.time.LocalDate;
 
 @Builder
-public record HistoryResponseDto(Long todoId, String content,LocalDate date) {
+public record HistoryResponseDto(Long todoId, String content) {
 }

--- a/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
+++ b/src/main/java/server/poptato/todo/application/response/PaginatedHistoryResponseDto.java
@@ -18,8 +18,7 @@ public class PaginatedHistoryResponseDto {
         this.histories = todosPage.getContent().stream()
                 .map(todo -> new HistoryResponseDto(
                         todo.getId(),
-                        todo.getContent(),
-                        todo.getCompletedDateTime().toLocalDate()
+                        todo.getContent()
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/server/poptato/todo/domain/entity/CompletedDateTime.java
+++ b/src/main/java/server/poptato/todo/domain/entity/CompletedDateTime.java
@@ -1,0 +1,39 @@
+package server.poptato.todo.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CompletedDateTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long todoId;
+
+    @NotNull
+    private LocalDateTime dateTime;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+
+    @Builder
+    public CompletedDateTime(Long todoId, LocalDateTime dateTime) {
+        this.todoId = todoId;
+        this.dateTime = dateTime;
+    }
+}

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -12,6 +12,8 @@ import server.poptato.todo.domain.value.Type;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -34,6 +36,8 @@ public class Todo{
     private LocalDate deadline;
     @NotNull
     private boolean isBookmark;
+    @NotNull
+    private boolean isRepeat;
     @Nullable
     private LocalDate todayDate;
     @Enumerated(EnumType.STRING)
@@ -42,8 +46,6 @@ public class Todo{
     private Integer todayOrder;
     @Nullable
     private Integer backlogOrder;
-    @Nullable
-    private LocalDateTime completedDateTime;
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createDate;
@@ -99,18 +101,15 @@ public class Todo{
     public void updateTodayStatusToInComplete(int minTodayOrder) {
         this.todayStatus = TodayStatus.INCOMPLETE;
         this.todayOrder = --minTodayOrder;
-        this.completedDateTime = null;
     }
 
     public void updateTodayStatusToCompleted() {
         this.todayStatus = TodayStatus.COMPLETED;
-        this.completedDateTime = LocalDateTime.now();
         this.todayOrder = null;
     }
 
     public void updateYesterdayStatusToCompleted() {
         this.todayStatus = TodayStatus.COMPLETED;
-        this.completedDateTime = LocalDateTime.now();
         this.backlogOrder = null;
     }
 

--- a/src/main/java/server/poptato/todo/domain/entity/TodoCategory.java
+++ b/src/main/java/server/poptato/todo/domain/entity/TodoCategory.java
@@ -1,0 +1,33 @@
+package server.poptato.todo.domain.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TodoCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    private Long todoId;
+    @NotNull
+    private Long categoryId;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
@@ -1,0 +1,14 @@
+package server.poptato.todo.domain.repository;
+
+import server.poptato.todo.domain.entity.CompletedDateTime;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface CompletedDateTimeRepository {
+    Optional<CompletedDateTime> findByDateAndTodoId(Long id, LocalDate todayDate);
+    boolean existsByDateTimeAndTodoId(LocalDateTime dateTime, Long todoId);
+    void delete(CompletedDateTime completedDateTime);
+    CompletedDateTime save(CompletedDateTime completedDateTime);
+}

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -16,14 +16,13 @@ public interface TodoRepository {
     List<Todo> findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByTodayOrderDesc(
             Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
 
-    List<Todo> findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByCompletedDateTimeAsc(
-            Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus);
+    List<Todo> findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(Long userId, LocalDate todayDate);
 
     Optional<Todo> findById(Long todoId);
 
     void delete(Todo todo);
 
-    Page<Todo> findByUserIdAndCompletedStatusAndDifferentTodayDate(Long userId, TodayStatus todayStatus, LocalDate today, Pageable pageable);
+    Page<Todo> findByUserIdAndCompletedStatus(Long userId, TodayStatus todayStatus, Pageable pageable);
 
     Todo save(Todo todo);
 
@@ -50,13 +49,13 @@ public interface TodoRepository {
                 userId, type, todayDate, todayStatus);
     }
 
-    default List<Todo> findCompletedTodays(Long userId, Type type, LocalDate todayDate, TodayStatus todayStatus) {
-        return findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByCompletedDateTimeAsc(
-                userId, type, todayDate, todayStatus);
+    default List<Todo> findCompletedTodays(Long userId, LocalDate todayDate) {
+        return findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(
+                userId, todayDate);
     }
 
-    default Page<Todo> findHistories(Long userId, LocalDate today, Pageable pageable) {
-        return findByUserIdAndCompletedStatusAndDifferentTodayDate(userId, TodayStatus.COMPLETED, today, pageable);
+    default Page<Todo> findHistories(Long userId,Pageable pageable) {
+        return findByUserIdAndCompletedStatus(userId, TodayStatus.COMPLETED, pageable);
     }
 
     List<Todo> findByType(Type type);

--- a/src/main/java/server/poptato/todo/exception/errorcode/TodoExceptionErrorCode.java
+++ b/src/main/java/server/poptato/todo/exception/errorcode/TodoExceptionErrorCode.java
@@ -17,7 +17,8 @@ public enum TodoExceptionErrorCode implements ResponseStatus {
     ALREADY_COMPLETED_TODO(5003, HttpStatus.BAD_REQUEST.value(), "달성된 할 일은 스와이프할 수 없습니다."),
     TODO_TYPE_NOT_MATCH(5004, HttpStatus.BAD_REQUEST.value(), "드래그앤드롭 시 할 일 리스트와 할 일 타입이 맞지 않습니다." ),
     BACKLOG_CANT_COMPLETE(5005,HttpStatus.BAD_REQUEST.value(), "백로그 할 일은 달성할 수 없습니다."),
-    YESTERDAY_CANT_COMPLETE(5006, HttpStatus.BAD_REQUEST.value(), "이미 달성한 어제 한 일은 취소할 수 없습니다.");
+    YESTERDAY_CANT_COMPLETE(5006, HttpStatus.BAD_REQUEST.value(), "이미 달성한 어제 한 일은 취소할 수 없습니다."),
+    COMPLETED_DATETIME_NOT_EXIST(5007, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 달성 시각입니다.");
 
 
     private final int code;

--- a/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
@@ -1,0 +1,19 @@
+package server.poptato.todo.infra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import server.poptato.todo.domain.entity.CompletedDateTime;
+import server.poptato.todo.domain.repository.CompletedDateTimeRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface JpaCompletedDateTimeRepository extends CompletedDateTimeRepository, JpaRepository<CompletedDateTime,Long> {
+    @Query("""
+    SELECT c
+    FROM CompletedDateTime c 
+    WHERE c.todoId = :todoId AND FUNCTION('DATE', c.dateTime) = :todayDate
+    """)
+    Optional<CompletedDateTime> findByDateAndTodoId(@Param("todoId") Long todoId, @Param("todayDate") LocalDate todayDate);
+}

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -26,11 +26,10 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo,Lo
     Integer findMinBacklogOrderByUserIdOrZero(@Param("userId") Long userId);
     @Query("SELECT COALESCE(MIN(t.todayOrder), 0) FROM Todo t WHERE t.userId = :userId AND t.todayOrder IS NOT NULL")
     Integer findMinTodayOrderByUserIdOrZero(Long userId);
-    @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.todayStatus = :todayStatus AND t.todayDate <> :todayDate")
-    Page<Todo> findByUserIdAndCompletedStatusAndDifferentTodayDate(
+    @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND t.todayStatus = :todayStatus")
+    Page<Todo> findByUserIdAndCompletedStatus(
             @Param("userId") Long userId,
             @Param("todayStatus") TodayStatus todayStatus,
-            @Param("todayDate") LocalDate todayDate,
             Pageable pageable
     );
     @Query("SELECT t FROM Todo t WHERE t.userId = :userId AND (t.type IN :types AND (t.todayStatus NOT IN :statuses OR t.todayStatus IS NULL)) " +
@@ -40,4 +39,18 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo,Lo
             @Param("types") List<Type> types,
             @Param("statuses") List<TodayStatus> statuses,
             Pageable pageable);
+    @Query("""
+    SELECT t 
+    FROM Todo t
+    JOIN CompletedDateTime c ON t.id = c.todoId
+    WHERE t.userId = :userId 
+      AND t.type = 'TODAY'
+      AND t.todayStatus = 'COMPLETED'
+      AND FUNCTION('DATE', c.dateTime) = :todayDate
+    ORDER BY c.dateTime ASC
+    """)
+    List<Todo> findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(
+            @Param("userId") Long userId,
+            @Param("todayDate") LocalDate todayDate
+    );
 }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.lang.Nullable;
 
 import java.time.LocalDateTime;
 
@@ -30,6 +31,9 @@ public class User {
 
     @NotNull
     private String email;
+
+    @Nullable
+    private String imageUrl;
 
     @CreatedDate  // 엔티티가 처음 생성될 때 시간 자동 저장
     @Column(updatable = false)  // 생성일은 수정 불가

--- a/src/test/java/server/poptato/todo/application/TodoBacklogServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoBacklogServiceTest.java
@@ -98,13 +98,6 @@ class TodoBacklogServiceTest {
         assertThat(actualSize).isLessThanOrEqualTo(size);
         assertThat(historiesPage.getTotalPageCount()).isGreaterThan(0);
 
-        List<HistoryResponseDto> histories = historiesPage.getHistories();
-        for (int i = 0; i < histories.size() - 1; i++) {
-            LocalDate current = histories.get(i).date();
-            LocalDate next = histories.get(i + 1).date();
-
-            assertThat(current).isAfterOrEqualTo(next);
-        }
     }
 
 

--- a/src/test/java/server/poptato/todo/application/TodoBacklogServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoBacklogServiceTest.java
@@ -80,7 +80,6 @@ class TodoBacklogServiceTest {
         assertThat(newTodo.getType()).isEqualTo(Type.BACKLOG);
         assertThat(newTodo.isBookmark()).isFalse();
         assertThat(newTodo.getTodayStatus()).isNull();
-        assertThat(newTodo.getCompletedDateTime()).isNull();
     }
     @Test
     @DisplayName("기록 조회 시 페이징 및 정렬하여 기록 조회를 성공한다.")

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -11,6 +11,7 @@ import server.poptato.todo.api.request.DragAndDropRequestDto;
 import server.poptato.todo.api.request.SwipeRequestDto;
 import server.poptato.todo.application.response.TodoDetailResponseDto;
 import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.CompletedDateTimeRepository;
 import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
@@ -32,6 +33,8 @@ class TodoServiceTest {
     private TodoService todoService;
     @Autowired
     private TodoRepository todoRepository;
+    @Autowired
+    private CompletedDateTimeRepository completedDateTimeRepository;
 
     @DisplayName("할일 삭제 시 성공한다.")
     @Test
@@ -290,12 +293,12 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 1L;
-        LocalDateTime updateDateTime = LocalDateTime.now();
+        LocalDateTime updateDateTime = LocalDateTime.of(2024,10,16,10,0,0,0);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
@@ -308,31 +311,30 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 35L;
-        LocalDateTime updateDateTime = LocalDateTime.now();
+        LocalDateTime updateDateTime = LocalDateTime.of(2024,11,11,10,0,0);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDateTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
-        assertThat(findTodo.getCompletedDateTime()).isNotNull();
         assertThat(isExist).isTrue();
     }
 
     @DisplayName("투데이 달성 취소 시 성공한다.")
     @Test
-    void updateIsCompleted_Today_Success() {
+    void updateIsCompleted_Today_toIncomplete_Success() {
         //given
         Long userId = 1L;
         Long todoId = 3L;
-        LocalDateTime updateDateTime = LocalDateTime.now();
+        LocalDateTime updateDateTime = LocalDateTime.of(2024,10,16,10,00,00);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDateTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
@@ -345,9 +347,10 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 20L;
+        LocalDateTime updateDateTime = LocalDateTime.now();
 
         //when & then
-        assertThatThrownBy(() -> todoService.updateIsCompleted(userId, todoId))
+        assertThatThrownBy(() -> todoService.updateIsCompleted(userId, todoId, updateDateTime))
                 .isInstanceOf(TodoException.class)
                 .hasMessage(TodoExceptionErrorCode.BACKLOG_CANT_COMPLETE.getMessage());
     }

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -18,6 +18,7 @@ import server.poptato.todo.exception.TodoException;
 import server.poptato.todo.exception.errorcode.TodoExceptionErrorCode;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -283,36 +284,59 @@ class TodoServiceTest {
         assertThat(findTodo.getContent()).isEqualTo(updateContent);
     }
 
-    @DisplayName("투데이 달성여부 변경 시 성공한다.")
+    @DisplayName("투데이 달성 시 성공한다.")
     @Test
     void updateIsCompleted_Today_Success() {
         //given
         Long userId = 1L;
         Long todoId = 1L;
+        LocalDateTime updateDateTime = LocalDateTime.now();
 
         //when
-        todoService.updateIsCompleted(userId, todoId);
+        todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
+        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
-        assertThat(findTodo.getCompletedDateTime()).isNotNull();
+        assertThat(isExist).isTrue();
     }
 
-    @DisplayName("어제한일 달성여부 변경 시 성공한다.")
+    @DisplayName("어제한일 달성 시 성공한다.")
     @Test
     void updateIsCompleted_Yesterday_Success() {
         //given
         Long userId = 1L;
         Long todoId = 35L;
+        LocalDateTime updateDateTime = LocalDateTime.now();
 
         //when
-        todoService.updateIsCompleted(userId, todoId);
+        todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
+        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
         assertThat(findTodo.getCompletedDateTime()).isNotNull();
+        assertThat(isExist).isTrue();
+    }
+
+    @DisplayName("투데이 달성 취소 시 성공한다.")
+    @Test
+    void updateIsCompleted_Today_Success() {
+        //given
+        Long userId = 1L;
+        Long todoId = 3L;
+        LocalDateTime updateDateTime = LocalDateTime.now();
+
+        //when
+        todoService.updateIsCompleted(userId, todoId, updateDateTime);
+        Todo findTodo = todoRepository.findById(todoId).get();
+        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+
+        //then
+        assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+        assertThat(isExist).isFalse();
     }
 
     @DisplayName("할 일 달성 여부 변경 시 백로그이면 예외가 발생한다.")

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -313,7 +313,7 @@ class TodoServiceTest {
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
@@ -332,7 +332,7 @@ class TodoServiceTest {
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDatetTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.isExistByDateTimeAndTodoId(updateDateTime,todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);

--- a/src/test/java/server/poptato/todo/domain/repository/TodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/domain/repository/TodoRepositoryTest.java
@@ -30,7 +30,7 @@ class TodoRepositoryTest {
         LocalDate todayDate = LocalDate.of(2024, 10, 16);
 
         //when
-        List<Todo> todos = todoRepository.findByUserIdAndTypeAndTodayDateAndTodayStatusOrderByCompletedDateTimeAsc(
+        List<Todo> todos = todoRepository.findByUserIdAndOrderByCompletedDateTimeAsc(
                 userId, Type.TODAY, todayDate, TodayStatus.COMPLETED);
 
         //then
@@ -39,7 +39,10 @@ class TodoRepositoryTest {
         assertThat(todos.stream().allMatch(todo -> todo.getType() == Type.TODAY)).isTrue();
         assertThat(todos.stream().allMatch(todo -> todo.getTodayDate().equals(todayDate))).isTrue();
         for (int i = 0; i < todos.size() - 1; i++) {
-            assertThat(todos.get(i).getCompletedDateTime()).isBeforeOrEqualTo(todos.get(i + 1).getCompletedDateTime());
+            LocalDateTime currentCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i).getId(), todayDate);
+            LocalDateTime nextCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i + 1).getId(), todayDate);
+
+            assertThat(currentCompletionTime).isBeforeOrEqualTo(nextCompletionTime); // 정렬 확인
         }
     }
 

--- a/src/test/java/server/poptato/todo/domain/repository/TodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/domain/repository/TodoRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import server.poptato.todo.domain.entity.CompletedDateTime;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
@@ -21,6 +22,8 @@ import java.util.List;
 class TodoRepositoryTest {
     @Autowired
     private TodoRepository todoRepository;
+    @Autowired
+    private CompletedDateTimeRepository completedDateTimeRepository;
 
     @DisplayName("달성된 투데이 조회 시, userId가 1이 등록한 달성된 투데이가 달성 시각 순서에 따라 성공적으로 정렬되어 조회된다.")
     @Test
@@ -30,8 +33,8 @@ class TodoRepositoryTest {
         LocalDate todayDate = LocalDate.of(2024, 10, 16);
 
         //when
-        List<Todo> todos = todoRepository.findByUserIdAndOrderByCompletedDateTimeAsc(
-                userId, Type.TODAY, todayDate, TodayStatus.COMPLETED);
+        List<Todo> todos = todoRepository.findCompletedTodayByUserIdOrderByCompletedDateTimeAsc(
+                userId, todayDate);
 
         //then
         assertThat(todos).isNotEmpty();
@@ -39,10 +42,10 @@ class TodoRepositoryTest {
         assertThat(todos.stream().allMatch(todo -> todo.getType() == Type.TODAY)).isTrue();
         assertThat(todos.stream().allMatch(todo -> todo.getTodayDate().equals(todayDate))).isTrue();
         for (int i = 0; i < todos.size() - 1; i++) {
-            LocalDateTime currentCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i).getId(), todayDate);
-            LocalDateTime nextCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i + 1).getId(), todayDate);
+            CompletedDateTime currentCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i).getId(), todayDate).get();
+            CompletedDateTime nextCompletionTime = completedDateTimeRepository.findByDateAndTodoId(todos.get(i + 1).getId(), todayDate).get();
 
-            assertThat(currentCompletionTime).isBeforeOrEqualTo(nextCompletionTime); // 정렬 확인
+            assertThat(currentCompletionTime.getDateTime()).isBeforeOrEqualTo(nextCompletionTime.getDateTime()); // 정렬 확인
         }
     }
 
@@ -92,14 +95,13 @@ class TodoRepositoryTest {
     void findHistories_Success(){
         //given
         Long userId = 1L;
-        LocalDate today = LocalDate.of(2024,10,30);
-        Pageable pageable = PageRequest.of(0, 15, Sort.by(Sort.Direction.DESC, "completedDateTime"));
+        Pageable pageable = PageRequest.of(0, 15);
 
         //when
-        Page<Todo> histories = todoRepository.findHistories(userId, today, pageable);
+        Page<Todo> histories = todoRepository.findHistories(userId, pageable);
 
         //then
         assertThat(histories).isNotNull();
-        assertThat(histories.getContent().size()).isEqualTo(6);
+        assertThat(histories.getContent().size()).isEqualTo(9);
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #5 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- ERD 2차 버전으로 코드 수정하고, 발생하는 관련 오류를 모두 해결하였습니다.

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 달성될 시 todo의 completeDateTime 필드가 아닌 completeDateTime 테이블에 데이터가 저장됩니다!
- Todo의 completeDateTime 필드와 연관있는 기능(달성여부 수정, 투데이 조회) 코드를 수정하였습니다.
- CompletedDateTime은 Todo의 생명로직과 연결되어 있어 Todo 도메인 폴더에 넣었습니다.
- TodoCategory(관계 테이블)도 Todo의 생명로직과 연관되어있다고 판단하여 Todo 도메인 폴더에 넣었습니다.
- 그 외 Category, Emoji는 별도의 도메인으로 구성하였습니다.

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- getHistory 부분에서 completeDateTime을 사용하는 코드를 아예 제거하였습니다. 2차부터는 기록 조회 기능 로직이 아예 변경되므로 다시 코드를 작성하면 될 것 같습니다!
