### PR TITLE
Feat#20: 달성여부 변경 API 2차 버전으로 수정

### DIFF
--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -100,19 +100,24 @@ public class Todo{
         this.content = content;
     }
 
-    public void updateTodayStatusToInComplete(int minTodayOrder) {
+    public void updateTodayToInComplete(int minTodayOrder) {
         this.todayStatus = TodayStatus.INCOMPLETE;
         this.todayOrder = --minTodayOrder;
     }
 
-    public void updateTodayStatusToCompleted() {
+    public void updateTodayToCompleted() {
         this.todayStatus = TodayStatus.COMPLETED;
         this.todayOrder = null;
     }
 
-    public void updateYesterdayStatusToCompleted() {
+    public void updateYesterdayToCompleted() {
         this.todayStatus = TodayStatus.COMPLETED;
         this.backlogOrder = null;
+    }
+
+    public void updateYesterdayToInComplete(int minBacklogOrder) {
+        this.todayStatus = TodayStatus.COMPLETED;
+        this.backlogOrder = --minBacklogOrder;
     }
 
     public void setType(Type type) {

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import server.poptato.category.exception.CategoryException;
-import server.poptato.category.exception.errorcode.CategoryExceptionErrorCode;
 import server.poptato.todo.api.request.*;
 import server.poptato.todo.application.response.HistoryCalendarListResponseDto;
 import server.poptato.todo.application.response.HistoryResponseDto;
@@ -23,6 +22,7 @@ import server.poptato.todo.exception.errorcode.TodoExceptionErrorCode;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -323,7 +323,7 @@ class TodoServiceTest {
                 .build();
 
         //when & then
-        assertThatThrownBy(()->todoService.updateCategory(userId, todoId, requestDto))
+        assertThatThrownBy(() -> todoService.updateCategory(userId, todoId, requestDto))
                 .isInstanceOf(CategoryException.class)
                 .hasMessage(CATEGORY_NOT_EXIST.getMessage());
     }
@@ -340,12 +340,10 @@ class TodoServiceTest {
                 .build();
 
         //when & then
-        assertThatThrownBy(()->todoService.updateCategory(userId, todoId, requestDto))
+        assertThatThrownBy(() -> todoService.updateCategory(userId, todoId, requestDto))
                 .isInstanceOf(CategoryException.class)
                 .hasMessage(CATEGORY_USER_NOT_MATCH.getMessage());
     }
-
-
 
 
     @DisplayName("투데이 달성 시 성공한다.")
@@ -354,12 +352,12 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 1L;
-        LocalDateTime updateDateTime = LocalDateTime.of(2024,10,16,10,0,0,0);
+        LocalDateTime updateDateTime = LocalDateTime.of(2024, 10, 16, 10, 0, 0, 0);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime, todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
@@ -372,12 +370,12 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 35L;
-        LocalDateTime updateDateTime = LocalDateTime.of(2024,11,11,10,0,0);
+        LocalDateTime updateDateTime = LocalDateTime.of(2024, 11, 11, 10, 0, 0);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(LocalDateTime.of(findTodo.getTodayDate(), LocalTime.of(23,59)), todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
@@ -390,12 +388,12 @@ class TodoServiceTest {
         //given
         Long userId = 1L;
         Long todoId = 3L;
-        LocalDateTime updateDateTime = LocalDateTime.of(2024,10,16,10,00,00);
+        LocalDateTime updateDateTime = LocalDateTime.of(2024, 10, 16, 10, 00, 00);
 
         //when
         todoService.updateIsCompleted(userId, todoId, updateDateTime);
         Todo findTodo = todoRepository.findById(todoId).get();
-        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime,todoId);
+        Boolean isExist = completedDateTimeRepository.existsByDateTimeAndTodoId(updateDateTime, todoId);
 
         //then
         assertThat(findTodo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
@@ -415,6 +413,7 @@ class TodoServiceTest {
                 .isInstanceOf(TodoException.class)
                 .hasMessage(TodoExceptionErrorCode.BACKLOG_CANT_COMPLETE.getMessage());
     }
+
     @Test
     @DisplayName("기록 조회 시 페이징 및 정렬하여 기록 조회를 성공한다.")
     void getHistories_Success() {
@@ -433,12 +432,13 @@ class TodoServiceTest {
 
         assertThat(actualSize).isLessThanOrEqualTo(size);
         assertThat(historiesPage.getTotalPageCount()).isEqualTo(2);
-        for(int i = 0; i<histories.size()-1; i++){
+        for (int i = 0; i < histories.size() - 1; i++) {
             CompletedDateTime current = completedDateTimeRepository.findByDateAndTodoId(histories.get(i).todoId(), date).get();
-            CompletedDateTime next = completedDateTimeRepository.findByDateAndTodoId(histories.get(i+1).todoId(), date).get();
+            CompletedDateTime next = completedDateTimeRepository.findByDateAndTodoId(histories.get(i + 1).todoId(), date).get();
             assertThat(current.getDateTime()).isBefore(next.getDateTime());
         }
     }
+
     @Test
     @DisplayName("캘린더 조회 시 기록이 있는 날짜들 반환을 성공한다")
     void getCalendar_Success() {


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #20
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 달성여부 변경 API 2차 버전으로 수정

## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- Today
    - 달성 → 미달성 시, todayOrder를 배정하고 status를 갱신 및 completedDateTime에서 row를 삭제합니다.
    - 미달성 → 달성 시, todayOrder를 삭제하고, status를 갱신 및 completedDateTime에서 row를 추가합니다.
- Yesterday
    - 달성 → 미달성 시, backlogOrder를 배정하고 status를 갱신 및 completedDateTime에서 row를 삭제합니다.
    - 미달성 → 달성 시, backlogOrder를 삭제하고 status를 갱신 및 completedDateTime에서 row를 추가합니다.
        - 단, 해당 row는 갱신 시각이 아닌 어제 날짜로 들어갑니다.!

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 
