### PR TITLE
Feat#33: 스케줄러 2차 기능 반영

### DIFF
--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -105,7 +105,7 @@ public class Todo{
         this.todayDate = null;
     }
 
-    public void setTodayOrder(int order) {
+    public void setTodayOrder(Integer order) {
         this.todayOrder = order;
     }
 

--- a/src/test/java/server/poptato/todo/application/TodoSchedulerTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoSchedulerTest.java
@@ -53,27 +53,22 @@ class TodoSchedulerTest {
 
         //then
         List<Todo> yesterdayTasks = todoRepository.findByType(Type.YESTERDAY);
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 1")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 2")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 4")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 5")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 7")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 8")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 10")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 12")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 14")));
-        assertTrue(yesterdayTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 16")));
+        List<Long> expectedYesterdays = List.of(1L, 2L, 4L, 5L, 7L, 8L, 10L, 12L, 14L, 16L, 38L, 39L);
+        assertTasksContainIds(yesterdayTasks, expectedYesterdays);
 
         List<Todo> backlogTasks = todoRepository.findByType(Type.BACKLOG);
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 1")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 2")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 3")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 4")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 5")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 6")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 7")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 8")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 9")));
-        assertTrue(backlogTasks.stream().anyMatch(todo -> todo.getContent().equals("할 일 10")));
+        List<Long> expectedBacklogs = List.of(3L, 6L, 27L, 28L, 29L, 30L, 31L, 32L, 33L, 34L, 35L, 36L, 37L);
+        assertTasksContainIds(backlogTasks, expectedBacklogs);
+    }
+
+    private void assertTasksContainIds(List<Todo> tasks, List<Long> expectedIds) {
+        List<Long> taskIds = tasks.stream()
+                .map(Todo::getId)
+                .toList();
+        assertTrue(taskIds.containsAll(expectedIds),
+                () -> "다음 할 일이 포함되어있지 않습니다: " +
+                        expectedIds.stream()
+                                .filter(content -> !taskIds.contains(content))
+                                .toList());
     }
 }


### PR DESCRIPTION
<!-- Title Convention
- 하나의 커밋일 경우 해당 커밋 메시지와 동일하게 작성한다.
- 여러 커밋이 포함된 경우 요약되어야 한다.
- 서술 : 첫 글자는 대문자.
- 예) Feat(jwt)#13: Add JWT Token For Authorization
--> 

Resolves #33 
<!--
e.g. Resolves #10 / Resolves #123,#345,#456 / Resolves #없음
-->

## Issue Define
<!-- 해당 이슈를 정의/설명해 주세요 -->
- 다음 기준에 따라 타입을 변경해주었습니다.
💡변경 기준
  - 미달성 + 반복O Today → YESTERDAY
  - 미달성 + 반복X Today → YESTERDAY
  - 달성 + 반복O Today → BACKLOG
  - 달성 + 반복X Today → X (변경 없음)
  - 미달성 + 반복O Yesterday → BACKLOG
  - 미달성 + 반복X Yesterday → BACKLOG
  - 달성 + 반복O Yesterday → BACKLOG
  - 달성 + 반복X Yesterday → X (변경 없음)
  - 
## Summary of resolutions or improvements
<!-- 해결/개선 사항을 요약해 주세요. 이미지를 첨부해도 좋습니다. -->
- 지금 든 생각인데... 굳이 YESTERDAY 타입이 있어야할까요..? 생각해보니까 어제한일 조회할 때 편하다 뺴고는 다른 기능에서는 오히려 로직이 다 복잡해지는 것 같아서... 2차 리팩토링 때 고려해봅시다 😢  

### Note

<!-- 참고 자료, 참고 사항, 리뷰어에게 전하는 메시지 등 -->
- 
